### PR TITLE
Docker name mangling and useradd

### DIFF
--- a/dox/runner.py
+++ b/dox/runner.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class Runner(object):
 
     def __init__(self, args, image_name=None):
-        image_name = image_name and "_" + image_name or ""
+        image_name = image_name and "/" + image_name or ""
         self.args = args
         self.project = os.path.basename(os.path.abspath('.'))
         self.base_image_name = 'dox/%s%s_base' % (self.project,
@@ -147,8 +147,9 @@ class Runner(object):
         try:
             tempd = tempfile.mkdtemp()
             if not self.user_map['username'] == 'root':
+                #check if user exists. If not, add them
                 dockerfile.append(
-                    "RUN useradd -M -U -d /src -u %(uid)s %(user)s" % dict(
+                    "RUN id -u %(user)s || useradd -M -U -d /src -u %(uid)s %(user)s" % dict(
                         uid=self.user_map['uid'],
                         gid=self.user_map['gid'],
                         user=self.user_map['username']))

--- a/dox/runner.py
+++ b/dox/runner.py
@@ -33,12 +33,12 @@ logger = logging.getLogger(__name__)
 class Runner(object):
 
     def __init__(self, args, image_name=None):
-        image_name = image_name and "/" + image_name or ""
+        image_name = image_name and image_name or ""
         self.args = args
         self.project = os.path.basename(os.path.abspath('.'))
-        self.base_image_name = 'dox/%s%s_base' % (self.project,
+        self.base_image_name = 'dox/%s%s-base' % (self.project,
                                                   image_name)
-        self.test_image_name = 'dox/%s%s_test' % (self.project,
+        self.test_image_name = 'dox/%s%s-test' % (self.project,
                                                   image_name)
         self.user_map = self._get_user_mapping()
         self.path_map = self._get_path_mapping()


### PR DESCRIPTION
There is no issues page, so I thought I would open a pull request. In my version of docker, 1.8.3, double underscores are disallowed for image names. This PR removes the underscores in name mangling. There are different ways to do this, by for example changing the default image name from `_default` to something else, but this works too. Also, some docker images I use for testing (jupyter/scipy-notebook) have non-root users and if I do a user-map that requires a useradd. I rewrote the useradd command to check if the user exists first.
